### PR TITLE
Add Git URL to show up in NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "files": [
     "index.js"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rowanwins/boolean-jsts.git"
+  },
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
Slightly annoying to not have a link to the GitHub repo in NPM, my library didn't include it at the time you copied it over. I've been adding these Git URL to make it easier to link NPM to GitHub.

https://www.npmjs.com/package/boolean-jsts